### PR TITLE
fix: replace broken GitHub V2 branch image URLs with main branch URLs

### DIFF
--- a/solayer-pay/tutorials/kyc.mdx
+++ b/solayer-pay/tutorials/kyc.mdx
@@ -16,7 +16,7 @@ Follow the steps below to get verified and claim your card!
 2. Click the **“Continue”** button to proceed with KYC.  
 3. You’ll be redirected to our verification partner, **Sumsub**.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step5.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step5.png" alt="" /></Frame>
 
 
 ## Step 2: Begin Verification with Sumsub
@@ -24,7 +24,7 @@ Follow the steps below to get verified and claim your card!
 1. On the Sumsub screen, click **“Continue”** to begin the KYC process for **Solayer Labs**.  
 2. Make sure you’re using a **secure internet connection**.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step6.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step6.png" alt="" /></Frame>
 
 
 ## Step 3: Confirm Your Country of Residence
@@ -33,7 +33,7 @@ Follow the steps below to get verified and claim your card!
    - ⚠️ If you are a U.S. resident, please select “United States of America”.
 2. Click **“Continue”** to proceed.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step7.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step7.png" alt="" /></Frame>
 
 
 ## Step 4: Choose Your Device for Verification
@@ -41,7 +41,7 @@ Follow the steps below to get verified and claim your card!
 1. You can complete the process on your current device or switch to your phone.  
 2. Click **“Continue on this device”** to proceed.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step9.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step9.png" alt="" /></Frame>
 
 
 ## Step 5: Enter Your Personal Information
@@ -58,7 +58,7 @@ Fill in the following details:
 
 Once complete, click **“Continue.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step10.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step10.png" alt="" /></Frame>
 
 
 ## Step 6: Email Verification
@@ -67,7 +67,7 @@ Once complete, click **“Continue.”**
 2. Click **“Send verification code.”**  
 3. Check your inbox and enter the code to verify your email.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step12.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step12.png" alt="" /></Frame>
 
 
 ## Step 7: Select Your Identity Document
@@ -76,7 +76,7 @@ Once complete, click **“Continue.”**
 2. Select the **issuing country**.  
 3. Click **“Continue.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step14.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step14.png" alt="" /></Frame>
 
 
 ## Step 8: Upload Your Identity Document
@@ -85,7 +85,7 @@ Once complete, click **“Continue.”**
 2. Accepted formats: **JPG, PNG, HEIC, WEBP, PDF** (max 50MB).  
 3. Click **“Continue.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step16.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step16.png" alt="" /></Frame>
 
 
 ## Step 9: Face Verification
@@ -94,7 +94,7 @@ Once complete, click **“Continue.”**
 2. Make sure your **face is clearly visible** and you’re **not wearing** hats, glasses, or masks.  
 3. Click **“Continue”** to start face verification.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step17.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step17.png" alt="" /></Frame>
 
 
 ## Step 10: KYC Complete
@@ -104,7 +104,7 @@ Once verified, you’ll see the message:
 
 Return to the **Solayer card page** to check your status and proceed with claiming your card.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step20.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step20.png" alt="" /></Frame>
 
 
 ## Step 11: Application Processing Time
@@ -112,7 +112,7 @@ Return to the **Solayer card page** to check your status and proceed with claimi
 - After completing KYC, your application will take **3–5 business days** to process.  
 - You will receive an **email notification** once your Solayer dashboard and card are ready.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step21.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step21.png" alt="" /></Frame>
 
 
 <br/>

--- a/solayer-pay/tutorials/register.mdx
+++ b/solayer-pay/tutorials/register.mdx
@@ -19,20 +19,20 @@ Follow the simple steps below to complete the card registration process in just 
 Tap the **“Card”** tab located on the navigation bar.  
 This will take you to the card registration page.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step1.png" alt="" /></Frame>
 
 ## Step 2: Tap “Pay & Activate”
 
 Tap the **“Pay & Activate”** button.  
 A pop-up will appear showing the card activation fee.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step2.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step2.png" alt="" /></Frame>
 
 
 ## Step 3: Confirm Payment
 
 Tap the **“Activate Card”** button to proceed with payment.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step3.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step3.png" alt="" /></Frame>
 
 
 > 💡 If you participated in Solayer Pay Pre-Sale, the activation fee will be waived.
@@ -42,34 +42,34 @@ Tap the **“Activate Card”** button to proceed with payment.
 ## Step 4: Approve the Transaction
 
 Confirm the payment transaction using your wallet or preferred payment method.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step4.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step4.png" alt="" /></Frame>
 
 
 ## Step 5: Continue to KYC
 
 After completing the payment, tap **“Continue”** to begin the identity verification (**KYC**) process.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step5.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step5.png" alt="" /></Frame>
 
 
 ## Step 6: Complete the KYC Process
 
 Follow the on-screen instructions to verify your identity.  
 Once verification is completed, your card registration will proceed.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step6.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step6.png" alt="" /></Frame>
 
 
 ## Step 7: Card Application in Process
 
 After KYC is approved, your **Solayer Pay** will be issued.  
 You may briefly see a processing screen during this stage.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step7.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step7.png" alt="" /></Frame>
 
 
 ## Step 8: Welcome to Your Solayer Pay
 
 Once issued, your card will appear in the app.  
 Tap **“Show Details”** to view your card number, expiration date, and CVV.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step8.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step8.png" alt="" /></Frame>
 
 <br/>
 

--- a/solayer-pay/tutorials/topup.mdx
+++ b/solayer-pay/tutorials/topup.mdx
@@ -14,32 +14,32 @@ You can easily deposit funds into your **Solayer Pay** to use it for **online** 
 - Connect your **wallet** to the **Solayer app**.  
 - Go to the **Card** tab.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step1.png" alt="" /></Frame>
 
 
 ## Step 2: Tap “Deposit”
 
 - Tap the **“Deposit”** button under your card.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step2.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step2.png" alt="" /></Frame>
 
 ## Step 3: Enter Amount
 
 - Input the **amount** you want to top up.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step3.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step3.png" alt="" /></Frame>
 
 ## Step 4: Confirm and Approve
 
 - Tap **“Deposit”**, then **approve the transaction** via your wallet or chosen payment method.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step4.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step4.png" alt="" /></Frame>
 
 ## Step 5: Check Your Balance
 
 - Once the transaction is confirmed, your **updated balance** will appear on the card screen.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step7.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step7.png" alt="" /></Frame>
 
 > 💡 A small fee of **$0.10** per top-up transaction is charged.
 <br/>

--- a/solayer-pay/tutorials/usage.mdx
+++ b/solayer-pay/tutorials/usage.mdx
@@ -14,7 +14,7 @@ Once your **Solayer Pay** is activated, you can easily access your card informat
 - Connect your **wallet** to the **Solayer app**.  
 - Go to the **Card** tab.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/details/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/details/step1.png" alt="" /></Frame>
 
 
 ## Step 2: Tap “View Details”
@@ -22,14 +22,14 @@ Once your **Solayer Pay** is activated, you can easily access your card informat
 - Tap **“View Details”** under your card.  
 - Your **card number**, **expiration date**, and **CVV** will be displayed.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/details/step2.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/details/step2.png" alt="" /></Frame>
 
 
 ## Step 3: Hide Details
 
 - To hide the card details, simply tap **“View Details”** again.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/details/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/details/step1.png" alt="" /></Frame>
 
 
 <br/>

--- a/tutorials/alipay.mdx
+++ b/tutorials/alipay.mdx
@@ -12,7 +12,7 @@ Solayer Pay is a Visa card issued internationally, and it can be added to Alipay
 - Launch the Alipay app on your smartphone.
 - Log in to your account.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/alipay/step1.jpg?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/alipay/step1.jpg" alt="" /></Frame>
 
 ## Step 2: Navigate to “Bank Card”
 
@@ -21,7 +21,7 @@ Solayer Pay is a Visa card issued internationally, and it can be added to Alipay
 
 > Note: Solayer Pay is a Visa international card. Some features may vary depending on your region.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/alipay/step2.jpg?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/alipay/step2.jpg" alt="" /></Frame>
 
 ## Step 3: Enter Your Card Information
 
@@ -32,26 +32,26 @@ Solayer Pay is a Visa card issued internationally, and it can be added to Alipay
   - CVV (Security Code)
 - Enter the card number into **Bank Card No.** field.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/alipay/step3.PNG?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/alipay/step3.PNG" alt="" /></Frame>
 
 ## Step 4: Add Expiry Date and CVV
 
 - Enter the expiration date (MM/YY) and CVV2 (3-digit security code) from the Solayer app.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/alipay/step4.jpg?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/alipay/step4.jpg" alt="" /></Frame>
 
 ## Step 5: Agree to Terms and Submit
 
 - Tap **Agree to Terms and Add** to complete the process.
 - Alipay will attempt to validate the card.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/alipay/step5.jpg?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/alipay/step5.jpg" alt="" /></Frame>
 
 ## Step 6: Card Added Successfully
 
 - A success screen will confirm that your Visa (Solayer) card has been added to **[My Bank Cards]**.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/alipay/step6.jpg?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/alipay/step6.jpg" alt="" /></Frame>
 
 ---
 

--- a/tutorials/cross/cross.mdx
+++ b/tutorials/cross/cross.mdx
@@ -15,7 +15,7 @@ This guide will walk you through the entire process using the Mayan integration 
 Visit [https://app.solayer.org](https://app.solayer.org) and click on the **Cross-chain** button under the sUSD section.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step1.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step1.png" alt="" />
 </Frame>
 
 ---
@@ -25,7 +25,7 @@ Visit [https://app.solayer.org](https://app.solayer.org) and click on the **Cros
 This will launch the **Mayan-powered cross-chain interface**. Choose the network you’re sending from (e.g., Ethereum).
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step2.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step2.png" alt="" />
 </Frame>
 
 ---
@@ -35,7 +35,7 @@ This will launch the **Mayan-powered cross-chain interface**. Choose the network
 Click **Select Destination Wallet** to proceed to choose your receiving Solana wallet (e.g., Phantom).
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step3.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step3.png" alt="" />
 </Frame>
 
 ---
@@ -45,7 +45,7 @@ Click **Select Destination Wallet** to proceed to choose your receiving Solana w
 Choose your Ethereum wallet (e.g., MetaMask), and approve the connection request.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step4.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step4.png" alt="" />
 </Frame>
 
 ---
@@ -56,7 +56,7 @@ Select the token you want to bridge (e.g., USDT), input the amount, and confirm 
 You will see an estimated amount in USDC after the bridge and fee deductions.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step5.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step5.png" alt="" />
 </Frame>
 
 ---
@@ -66,7 +66,7 @@ You will see an estimated amount in USDC after the bridge and fee deductions.
 You will be prompted to approve token allowance in MetaMask. Confirm the transaction.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step6.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step6.png" alt="" />
 </Frame>
 
 ---
@@ -76,7 +76,7 @@ You will be prompted to approve token allowance in MetaMask. Confirm the transac
 Once approval is complete, the **Deposit** button will activate. Click it to proceed with the actual cross-chain transfer.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step7.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step7.png" alt="" />
 </Frame>
 
 ---
@@ -87,7 +87,7 @@ Review the effective input, expected deposit amount, relayer fee, and destinatio
 Then click **Confirm Deposit**.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step12.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step12.png" alt="" />
 </Frame>
 
 ---
@@ -97,7 +97,7 @@ Then click **Confirm Deposit**.
 MetaMask will ask you to confirm the actual transfer. This includes gas fees and execution details.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step13.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step13.png" alt="" />
 </Frame>
 
 ---
@@ -108,7 +108,7 @@ Once submitted, you’ll see a confirmation modal.
 You can view the transaction in the **Mayan explorer**.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/cross/step14.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/cross/step14.png" alt="" />
 </Frame>
 
 ---

--- a/tutorials/details.mdx
+++ b/tutorials/details.mdx
@@ -14,7 +14,7 @@ Once your **Solayer Pay** is activated, you can easily access your card informat
 - Connect your **wallet** to the **Solayer app**.  
 - Go to the **Card** tab.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/details/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/details/step1.png" alt="" /></Frame>
 
 
 ## Step 2: Tap “View Details”
@@ -22,14 +22,14 @@ Once your **Solayer Pay** is activated, you can easily access your card informat
 - Tap **“View Details”** under your card.  
 - Your **card number**, **expiration date**, and **CVV** will be displayed.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/details/step2.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/details/step2.png" alt="" /></Frame>
 
 
 ## Step 3: Hide Details
 
 - To hide the card details, simply tap **“View Details”** again.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/details/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/details/step1.png" alt="" /></Frame>
 
 
 <br/>

--- a/tutorials/digital_wallets.mdx
+++ b/tutorials/digital_wallets.mdx
@@ -16,67 +16,67 @@ Follow the step-by-step instructions below to complete the setup on your device.
 - Open the **Wallet** app on your iPhone.  
 - Tap the **“+”** button at the top right.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step3.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step3.png" alt="" /></Frame>
 
 ### Step 2: Select Card Type
 - Tap **“Debit or Credit Card.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step4.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step4.png" alt="" /></Frame>
 
 ### Step 3: Continue Setup
 - Tap **“Continue.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step5.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step5.png" alt="" /></Frame>
 
 ### Step 4: Enter Card Info Manually
 - Choose **“Enter Card Details Manually.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step6.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step6.png" alt="" /></Frame>
 
 ### Step 5: Input Name & Card Number
 - Visit Card tap of Solayer App and click "View details" to get card details.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step1.png" alt="" /></Frame>
 
 - Enter your **name** and **card number** (copied from the Solayer app).
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step7.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step7.png" alt="" /></Frame>
 
 - Enter the card's **expiration date** and **CVV**.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step8.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step8.png" alt="" /></Frame>
 
 
 ### Step 6: Agree to Terms & Conditions
 - Read and tap **“Agree”** to continue.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step9.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step9.png" alt="" /></Frame>
 
 ### Step 8: Begin Card Verification
 - Choose to verify via **Text Message** or **Email**.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step10.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step10.png" alt="" /></Frame>
 
 - Get the code via Text Message or Email
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step11.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step11.png" alt="" /></Frame>
 
 
 - Input the code sent to your phone or email.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step12.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step12.png" alt="" /></Frame>
 
 - You’ll see a confirmation screen that your card has been added.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step13.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step13.png" alt="" /></Frame>
 
 - Double-click the side button, authenticate with Face ID, and tap your phone near a reader.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step14.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step14.png" alt="" /></Frame>
 
 ## Step 9: Confirmation in Wallet
 - You can now see your card listed in the Wallet app, ready for transactions.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/degital_wallets/step15.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/degital_wallets/step15.png" alt="" /></Frame>
 
 <br/>
 

--- a/tutorials/freeze.mdx
+++ b/tutorials/freeze.mdx
@@ -15,20 +15,20 @@ Freezing your card is **instant and reversible at any time**.
 - Connect your **wallet** to the **Solayer app**.  
 - Go to the **Card** tab.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/freeze/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/freeze/step1.png" alt="" /></Frame>
 
 ## Step 2: Tap “Freeze”
 
 - Tap the **“Freeze”** button below your card.  
 - Your card will be **temporarily disabled** and cannot be used for payments.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/freeze/step2.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/freeze/step2.png" alt="" /></Frame>
 
 ## Step 3: Tap “Unfreeze” to Reactivate
 
 - If you find your card or determine it’s safe to use, tap **“Unfreeze”** to restore full functionality.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/freeze/step4.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/freeze/step4.png" alt="" /></Frame>
 
 <br/>
 

--- a/tutorials/history.mdx
+++ b/tutorials/history.mdx
@@ -25,7 +25,7 @@ This feature helps you **track card activity**, **monitor spending**, and **catc
   - **Status**  
   - **Amount**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/history/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/history/step1.png" alt="" /></Frame>
 
 
 <br/>

--- a/tutorials/kyc.mdx
+++ b/tutorials/kyc.mdx
@@ -16,7 +16,7 @@ Follow the steps below to get verified and claim your card!
 2. Click the **“Continue”** button to proceed with KYC.  
 3. You’ll be redirected to our verification partner, **Sumsub**.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step5.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step5.png" alt="" /></Frame>
 
 
 ## Step 2: Begin Verification with Sumsub
@@ -24,7 +24,7 @@ Follow the steps below to get verified and claim your card!
 1. On the Sumsub screen, click **“Continue”** to begin the KYC process for **Solayer Labs**.  
 2. Make sure you’re using a **secure internet connection**.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step6.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step6.png" alt="" /></Frame>
 
 
 ## Step 3: Confirm Your Country of Residence
@@ -33,7 +33,7 @@ Follow the steps below to get verified and claim your card!
    - ⚠️ If you are a U.S. resident, please select “United States of America”.
 2. Click **“Continue”** to proceed.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step7.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step7.png" alt="" /></Frame>
 
 
 ## Step 4: Choose Your Device for Verification
@@ -41,7 +41,7 @@ Follow the steps below to get verified and claim your card!
 1. You can complete the process on your current device or switch to your phone.  
 2. Click **“Continue on this device”** to proceed.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step9.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step9.png" alt="" /></Frame>
 
 
 ## Step 5: Enter Your Personal Information
@@ -58,7 +58,7 @@ Fill in the following details:
 
 Once complete, click **“Continue.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step10.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step10.png" alt="" /></Frame>
 
 
 ## Step 6: Email Verification
@@ -67,7 +67,7 @@ Once complete, click **“Continue.”**
 2. Click **“Send verification code.”**  
 3. Check your inbox and enter the code to verify your email.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step12.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step12.png" alt="" /></Frame>
 
 
 ## Step 7: Select Your Identity Document
@@ -76,7 +76,7 @@ Once complete, click **“Continue.”**
 2. Select the **issuing country**.  
 3. Click **“Continue.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step14.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step14.png" alt="" /></Frame>
 
 
 ## Step 8: Upload Your Identity Document
@@ -85,7 +85,7 @@ Once complete, click **“Continue.”**
 2. Accepted formats: **JPG, PNG, HEIC, WEBP, PDF** (max 50MB).  
 3. Click **“Continue.”**
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step16.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step16.png" alt="" /></Frame>
 
 
 ## Step 9: Face Verification
@@ -94,7 +94,7 @@ Once complete, click **“Continue.”**
 2. Make sure your **face is clearly visible** and you’re **not wearing** hats, glasses, or masks.  
 3. Click **“Continue”** to start face verification.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step17.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step17.png" alt="" /></Frame>
 
 
 ## Step 10: KYC Complete
@@ -104,7 +104,7 @@ Once verified, you’ll see the message:
 
 Return to the **Solayer card page** to check your status and proceed with claiming your card.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step20.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step20.png" alt="" /></Frame>
 
 
 ## Step 11: Application Processing Time
@@ -112,7 +112,7 @@ Return to the **Solayer card page** to check your status and proceed with claimi
 - After completing KYC, your application will take **3–5 business days** to process.  
 - You will receive an **email notification** once your Solayer dashboard and card are ready.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/kyc/step21.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/kyc/step21.png" alt="" /></Frame>
 
 
 <br/>

--- a/tutorials/native/staking.mdx
+++ b/tutorials/native/staking.mdx
@@ -17,7 +17,7 @@ Go to [https://app.solayer.org](https://app.solayer.org) and connect your wallet
 From the **sSOL** section, click on the **Native Staking** link in the top right corner of the staking interface.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/native/staking/step1.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/native/staking/step1.png" alt="" />
 </Frame>
 
 ---
@@ -28,7 +28,7 @@ Enter the amount of SOL you want to natively stake.
 You’ll see your current balance and USD equivalent. Once ready, click **Deposit**.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/native/staking/step2.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/native/staking/step2.png" alt="" />
 </Frame>
 
 ---
@@ -39,7 +39,7 @@ Your wallet will request approval for the transaction.
 It will show a **staking account transfer** message and the estimated network fee. Click **Approve** to proceed.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/native/staking/step3.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/native/staking/step3.png" alt="" />
 </Frame>
 
 ---
@@ -49,7 +49,7 @@ It will show a **staking account transfer** message and the estimated network fe
 Once approved, a transaction confirmation will appear in the top right corner of the screen.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/native/staking/step4.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/native/staking/step4.png" alt="" />
 </Frame>
 
 ---
@@ -60,7 +60,7 @@ You can now see your staked balance reflected in the Native Staking panel.
 To increase your position, repeat the process with additional SOL.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/native/staking/step5.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/native/staking/step5.png" alt="" />
 </Frame>
 
 ---

--- a/tutorials/register.mdx
+++ b/tutorials/register.mdx
@@ -19,20 +19,20 @@ Follow the simple steps below to complete the card registration process in just 
 Tap the **“Card”** tab located on the navigation bar.  
 This will take you to the card registration page.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step1.png" alt="" /></Frame>
 
 ## Step 2: Tap “Pay & Activate”
 
 Tap the **“Pay & Activate”** button.  
 A pop-up will appear showing the card activation fee.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step2.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step2.png" alt="" /></Frame>
 
 
 ## Step 3: Confirm Payment
 
 Tap the **“Activate Card”** button to proceed with payment.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step3.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step3.png" alt="" /></Frame>
 
 
 > 💡 If you participated in Solayer Pay Pre-Sale, the activation fee will be waived.
@@ -42,34 +42,34 @@ Tap the **“Activate Card”** button to proceed with payment.
 ## Step 4: Approve the Transaction
 
 Confirm the payment transaction using your wallet or preferred payment method.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step4.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step4.png" alt="" /></Frame>
 
 
 ## Step 5: Continue to KYC
 
 After completing the payment, tap **“Continue”** to begin the identity verification (**KYC**) process.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step5.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step5.png" alt="" /></Frame>
 
 
 ## Step 6: Complete the KYC Process
 
 Follow the on-screen instructions to verify your identity.  
 Once verification is completed, your card registration will proceed.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step6.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step6.png" alt="" /></Frame>
 
 
 ## Step 7: Card Application in Process
 
 After KYC is approved, your **Solayer Pay** will be issued.  
 You may briefly see a processing screen during this stage.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step7.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step7.png" alt="" /></Frame>
 
 
 ## Step 8: Welcome to Your Solayer Pay
 
 Once issued, your card will appear in the app.  
 Tap **“Show Details”** to view your card number, expiration date, and CVV.
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/register/step8.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/register/step8.png" alt="" /></Frame>
 
 <br/>
 

--- a/tutorials/ssol/stake.mdx
+++ b/tutorials/ssol/stake.mdx
@@ -14,7 +14,7 @@ Solayer offers a high-performance staking experience powered by optimized hardwa
 Visit [https://app.solayer.org](https://app.solayer.org) and connect your wallet using the button at the top right corner. Solayer supports wallets such as **Solflare**, **Phantom**, and others that are compatible with the Solana network.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/stake/step1.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/stake/step1.png" alt="" />
 </Frame>
 
 ---
@@ -26,7 +26,7 @@ You will see the current exchange rate below the input field (e.g., `1 sSOL = 1.
 Once a valid amount is entered, the **Stake** button will become active.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/stake/step2.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/stake/step2.png" alt="" />
 </Frame>
 
 ---
@@ -43,7 +43,7 @@ Review the transaction details, including:
 Click **Approve** to proceed.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/stake/step3.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/stake/step3.png" alt="" />
 </Frame>
 
 ---
@@ -54,7 +54,7 @@ Once approved, a pending status will appear on the Solayer interface as the tran
 This typically completes within a few seconds.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/stake/step4.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/stake/step4.png" alt="" />
 </Frame>
 
 ---
@@ -65,7 +65,7 @@ After confirmation, you will see a **Transaction successful** message.
 Your staked SOL will now appear as **sSOL** in your wallet. You are now earning staking rewards through Solayer's validator infrastructure.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/stake/step5.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/stake/step5.png" alt="" />
 </Frame>
 
 ---

--- a/tutorials/ssol/unstake.mdx
+++ b/tutorials/ssol/unstake.mdx
@@ -15,7 +15,7 @@ Navigate to [https://app.solayer.org](https://app.solayer.org) and connect your 
 Then click the **Unstake** tab under the sSOL section.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step1.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step1.png" alt="" />
 </Frame>
 
 ---
@@ -26,7 +26,7 @@ Enter the amount of `sSOL` you want to unstake.
 You will see the equivalent SOL value based on the current exchange rate. Click **Unstake**.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step2.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step2.png" alt="" />
 </Frame>
 
 ---
@@ -43,7 +43,7 @@ Your wallet will display the transaction details. Review and confirm them, inclu
 Click **Approve** to proceed.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step3.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step3.png" alt="" />
 </Frame>
 
 ---
@@ -53,7 +53,7 @@ Click **Approve** to proceed.
 After confirming the transaction, you will see a **Transaction successful** message at the top right of the screen.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step4.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step4.png" alt="" />
 </Frame>
 
 ---
@@ -64,7 +64,7 @@ Next, you need to deactivate your stake. This begins a cooldown period that typi
 Click **Deactivate** when prompted.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step5.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step5.png" alt="" />
 </Frame>
 
 ---
@@ -75,7 +75,7 @@ You can monitor the progress of your unstaking in the **Pending transactions** s
 This area displays which stakes are deactivating and which are ready to withdraw.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step6.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step6.png" alt="" />
 </Frame>
 
 ---
@@ -85,7 +85,7 @@ This area displays which stakes are deactivating and which are ready to withdraw
 Once the cooldown period has passed, the **Withdraw** button will appear next to your entry. Click it to receive your SOL.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step7.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step7.png" alt="" />
 </Frame>
 
 ---
@@ -95,7 +95,7 @@ Once the cooldown period has passed, the **Withdraw** button will appear next to
 After withdrawing, you'll see a confirmation that your SOL has been successfully returned to your wallet.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/ssol/unstake/step8.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/ssol/unstake/step8.png" alt="" />
 </Frame>
 
 ---

--- a/tutorials/susd/deposit.mdx
+++ b/tutorials/susd/deposit.mdx
@@ -15,7 +15,7 @@ Go to [https://app.solayer.org](https://app.solayer.org), connect your wallet, a
 Ensure you are on the **Deposit** sub-tab, not Withdraw.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/deposit/step1.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/deposit/step1.png" alt="" />
 </Frame>
 
 ---
@@ -26,7 +26,7 @@ Enter the amount of `USDC` you want to deposit.
 You will see the exchange rate displayed as `1 sUSD = 1 USDC`. Click **Deposit** to continue.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/deposit/step2.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/deposit/step2.png" alt="" />
 </Frame>
 
 ---
@@ -37,7 +37,7 @@ A confirmation modal will appear, explaining that the deposit process may take u
 Click **Confirm Deposit** to proceed.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/deposit/step3.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/deposit/step3.png" alt="" />
 </Frame>
 
 ---
@@ -48,7 +48,7 @@ Your wallet will prompt you to approve the transaction.
 You will see the deduction of your USDC and a small network fee in SOL. Confirm the transaction by clicking **Approve**.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/deposit/step4.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/deposit/step4.png" alt="" />
 </Frame>
 
 ---
@@ -58,7 +58,7 @@ You will see the deduction of your USDC and a small network fee in SOL. Confirm 
 Once confirmed, you will see a **Pending** status at the top right. The transaction is now being processed in the background.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/deposit/step5.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/deposit/step5.png" alt="" />
 </Frame>
 
 ---
@@ -69,7 +69,7 @@ Once the deposit process is complete, a **Transaction successful** message will 
 You can now view your newly minted sUSD in your wallet.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/deposit/step6.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/deposit/step6.png" alt="" />
 </Frame>
 
 ---

--- a/tutorials/susd/withdraw.mdx
+++ b/tutorials/susd/withdraw.mdx
@@ -15,7 +15,7 @@ This tutorial covers the full withdrawal process, including timing, pending stat
 Navigate to [https://app.solayer.org](https://app.solayer.org), go to the **sUSD** section, and select the **Withdraw** tab.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step1.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step1.png" alt="" />
 </Frame>
 
 ---
@@ -25,7 +25,7 @@ Navigate to [https://app.solayer.org](https://app.solayer.org), go to the **sUSD
 Input the amount of sUSD you want to withdraw. You’ll see your wallet balance and estimated USDC equivalent.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step2.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step2.png" alt="" />
 </Frame>
 
 ---
@@ -35,7 +35,7 @@ Input the amount of sUSD you want to withdraw. You’ll see your wallet balance 
 After entering the amount, click the **Withdraw** button to proceed.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step3.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step3.png" alt="" />
 </Frame>
 
 ---
@@ -49,7 +49,7 @@ A modal will explain the withdrawal timeline:
 Click **Confirm Withdraw** to proceed.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step4.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step4.png" alt="" />
 </Frame>
 
 ---
@@ -60,7 +60,7 @@ Your connected wallet (e.g., Solflare or Phantom) will request transaction appro
 This includes sUSD burn and associated network fee. Click **Approve**.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step5.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step5.png" alt="" />
 </Frame>
 
 ---
@@ -71,7 +71,7 @@ Once submitted, a **pending** message will appear at the top right.
 You can track the progress in the **Pending transactions** section.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step6.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step6.png" alt="" />
 </Frame>
 
 ---
@@ -82,7 +82,7 @@ In the pending list, you'll see sUSD with a `Settling` or `Processing` status.
 Once the backend process is complete, it will be available for claim as USDC.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step7.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step7.png" alt="" />
 </Frame>
 
 ---
@@ -92,7 +92,7 @@ Once the backend process is complete, it will be available for claim as USDC.
 Once successful, you’ll see a transaction confirmation message like **"Withdraw sUSD – Transaction successful"**.
 
 <Frame>
-  <img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/susd/withdraw/step8.png?raw=true" alt="" />
+  <img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/susd/withdraw/step8.png" alt="" />
 </Frame>
 
 ---

--- a/tutorials/topup.mdx
+++ b/tutorials/topup.mdx
@@ -14,32 +14,32 @@ You can easily deposit funds into your **Solayer Pay** to use it for **online** 
 - Connect your **wallet** to the **Solayer app**.  
 - Go to the **Card** tab.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step1.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step1.png" alt="" /></Frame>
 
 
 ## Step 2: Tap “Deposit”
 
 - Tap the **“Deposit”** button under your card.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step2.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step2.png" alt="" /></Frame>
 
 ## Step 3: Enter Amount
 
 - Input the **amount** you want to top up.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step3.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step3.png" alt="" /></Frame>
 
 ## Step 4: Confirm and Approve
 
 - Tap **“Deposit”**, then **approve the transaction** via your wallet or chosen payment method.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step4.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step4.png" alt="" /></Frame>
 
 ## Step 5: Check Your Balance
 
 - Once the transaction is confirmed, your **updated balance** will appear on the card screen.
 
-<Frame><img src="https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/topup/step7.png?raw=true" alt="" /></Frame>
+<Frame><img src="https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/topup/step7.png" alt="" /></Frame>
 
 > 💡 A small fee of **$0.10** per top-up transaction is charged.
 <br/>


### PR DESCRIPTION
## Summary
- All tutorial images were referencing the non-existent `V2` branch on GitHub, causing 404 errors across `solayer-pay/tutorials/` and `tutorials/` pages
- Replaced all broken URLs from `https://github.com/SolayerDev/solayer_docs/blob/V2/tutorials/image/...?raw=true` to `https://raw.githubusercontent.com/SolayerDev/solayer_docs/main/tutorials/image/...`
- 18 files, 120 image URLs fixed

## Test plan
- [ ] Verify images load on https://docs.solayer.org/solayer-pay/tutorials/usage
- [ ] Verify images load on https://docs.solayer.org/solayer-pay/tutorials/kyc
- [ ] Verify images load on https://docs.solayer.org/solayer-pay/tutorials/register
- [ ] Verify images load on https://docs.solayer.org/solayer-pay/tutorials/topup

🤖 Generated with [Claude Code](https://claude.com/claude-code)