### PR TITLE
docs: update WalletConnect section in supported-wallets

### DIFF
--- a/documentation/introduction/supported-wallets.mdx
+++ b/documentation/introduction/supported-wallets.mdx
@@ -7,9 +7,9 @@ Solayer Chain currently has native integration support for **WalletConnect (Reow
 
 ---
 
-## WalletConnect (Reown AppKit)
+## WalletConnect (Reown SDK)
 
-[Reown AppKit](https://reown.com/appkit) is the standard wallet connection protocol supporting Solana and SVM-based chains, including Solayer Chain.
+WalletConnect lets you accept top Solana wallets such as Solflare, Phantom, Backpack, Jupiter, Ledger and many more ([see the full list here](https://explorer.walletconnect.com/?type=wallet&chains=solana%3A4sGjMW1scdkeTD4KoVHUkJ3i4RLRo7pJXupAqhd1s7j)). Via their Reown SDK, you can also access building tools beyond wallet connections; including authentication, payment solutions and multichain tools.
 
 **Supported frameworks:** React, Next.js, Vue, JavaScript, React Native
 
@@ -21,11 +21,11 @@ Solayer Chain currently has native integration support for **WalletConnect (Reow
 
 <CardGroup cols={2}>
   <Card
-    title="Reown AppKit — Solana"
+    title="Reown SDK — Solana"
     icon="link"
     href="https://docs.reown.com/appkit/networks/solana#solana"
   >
-    Framework-specific setup guides for AppKit with Solana
+    Framework-specific setup guides for Reown SDK with Solana
   </Card>
   <Card
     title="Solana Adapter (Advanced)"
@@ -37,7 +37,7 @@ Solayer Chain currently has native integration support for **WalletConnect (Reow
 </CardGroup>
 
 <Note>
-  If you're new to the Wallet Adapter library, Reown recommends using **AppKit** directly for a simpler multichain setup.
+  If you're new to the Wallet Adapter library, Reown recommends using the **Reown SDK** directly for a simpler multichain setup.
 </Note>
 
 ---


### PR DESCRIPTION
## Summary

- Rename **AppKit** to **Reown SDK** throughout the WalletConnect section
- Update description to highlight supported Solana wallets (Solflare, Phantom, Backpack, Jupiter, Ledger) with a link to the full list
- Add mention of broader Reown SDK capabilities: authentication, payment solutions, and multichain tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)