### PR TITLE
add LAYER staking docs for devnet

### DIFF
--- a/documentation/staking/delegate.mdx
+++ b/documentation/staking/delegate.mdx
@@ -1,0 +1,364 @@
+---
+title: "Delegate LAYER"
+description: "Stake LAYER to a validator, claim rewards, and unstake (devnet)"
+---
+
+If you're a token holder, this is the page you want. If you're an operator,
+this is also how you
+[self-delegate](/documentation/staking/run-a-validator#self-delegate-to-start-earning).
+
+## Prerequisites
+
+- A Solana wallet/keypair (the **same** keypair works on L1 and L2 — same
+  address space).
+- **LAYER in your wallet** — either already on the **L2** (the common case,
+  since LAYER is L2-native), or the **wrapped** form on L1 devnet (mint in the
+  [overview](/documentation/staking/overview#network-endpoints--addresses)),
+  which you bridge back below.
+- **SOL on L2** for L2 tx fees (native gas on the Solayer chain is SOL). If
+  you have none yet, seed it while bridging via the `additionalSolGas`
+  parameter, or bridge SOL separately.
+- **SOL on L1 devnet** — only if you're bridging from L1: it pays the bridge
+  tx + L1 fees (`solana airdrop 2 -u devnet`).
+- Node 18+ and these packages in your project:
+
+  ```bash
+  npm install @solayer-labs/bridge-sdk @coral-xyz/anchor \
+              @solana/web3.js @solana/spl-token
+  ```
+
+If you **already hold LAYER on the L2**, you don't need the bridge at all —
+skip straight to [Delegate](#delegate).
+
+## Bridge wrapped LAYER L1 to L2
+
+**Skip this section if you already hold LAYER on the L2** — since LAYER is
+L2-native, many holders never touch the bridge. Go straight to
+[Delegate](#delegate).
+
+LAYER's home mint lives on the L2; the Solana (L1) form is a **wrapped**
+representation created by the bridge. For a Solayer-native token the bridge
+directions are therefore the *reverse* of what you may know from
+Solana-native tokens:
+
+- **L2 → L1**: native LAYER is **locked in the L2 bridge vault**, and wrapped
+  LAYER is **minted on L1** by the bridge handler (which holds the wrapped
+  mint's authority).
+- **L1 → L2** (this section): your wrapped LAYER is **burned on L1**, and
+  native LAYER is **released from the L2 bridge vault** to your L2 address.
+
+You submit one transaction on L1; an off-chain **guardian** set observes it,
+multi-sig signs, and completes the release on L2. The whole thing is
+asynchronous — your L2 tokens appear once the guardians complete it (seconds
+to a couple of minutes).
+
+<Warning>
+**The L2 side pays out of a vault, not a mint.** An L1 → L2 release only
+works if the L2 bridge vault holds enough native LAYER — i.e. at least that
+much was previously bridged L2 → L1, or the team has seeded the vault. If
+the vault is short, your L1 burn still succeeds but the L2 completion
+cannot execute (`InsufficientFunds` on the bridge) until liquidity exists.
+You can check first: the vault is the LAYER ATA of the bridge handler PDA on
+the L2.
+</Warning>
+
+<Warning>
+**Bridge the wrapped form of LAYER, not just any token.** Once the staking
+program is live, it only accepts deposits of `Config.stake_mint` — the
+**native L2 LAYER mint**. For a Solayer-native token this is **not** the
+PDA-derived `["mint", bridgeHandler, l1Mint]` address (that derivation only
+applies to tokens whose home chain is the *source* chain, e.g. Solana-native
+tokens being wrapped onto the L2); what you receive on L2 is the original
+native mint recorded in the bridge's `TokenInfo` account. After bridging,
+confirm the mint you received **equals `Config.stake_mint`** (see
+[Check your position](#check-your-position--the-deployment)). If they
+differ, you bridged the wrong token and cannot stake it.
+</Warning>
+
+<Info>
+Only **legacy SPL Token (Token-2020)** mints and native SOL are bridgeable.
+**Token-2022 is not supported.**
+</Info>
+
+### Submit the bridge on L1
+
+```ts
+import { BridgeClient, Chain } from "@solayer-labs/bridge-sdk";
+import {
+  Connection, Keypair, PublicKey, sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import * as anchor from "@coral-xyz/anchor";
+
+const l1 = new Connection("https://api.devnet.solana.com", "confirmed");
+
+// Your wallet (load from file in real usage; same pubkey is your L2 address).
+const wallet = Keypair.fromSecretKey(/* ... */);
+
+// Wrapped LAYER mint on L1 (devnet). This is what gets burned.
+const L1_WRAPPED_LAYER = new PublicKey(
+  "CJYj22nRQ7uQAV6Rmvn4sy2NduBiFwLNqdqkmH6hWDEF",
+);
+
+const bridge = new BridgeClient({
+  connection: l1,
+  userPublicKey: wallet.publicKey,
+  chain: Chain.Solana,                  // bridging FROM Solana
+  commitment: "confirmed",
+});
+
+const params = {
+  bridgeProofNonce: new anchor.BN(Date.now()),   // any unique nonce
+  amount: new anchor.BN(1_000_000_000),          // base units — respect decimals
+  recipient: wallet.publicKey,                   // who receives on L2 (you)
+  additionalSolGas: new anchor.BN(5_000_000),    // optional: seed ~0.005 SOL on L2
+};
+
+const accounts = {
+  mint: L1_WRAPPED_LAYER,
+  signerVault: getAssociatedTokenAddressSync(L1_WRAPPED_LAYER, wallet.publicKey),
+};
+
+const tx = await bridge.createBridgeAssetSourceChainTransaction(params, accounts);
+const l1Sig = await sendAndConfirmTransaction(l1, tx, [wallet]);
+console.log("L1 bridge tx:", l1Sig);
+```
+
+Because wrapped LAYER is a bridge-created token (not native to L1), this
+transaction **burns** it from your L1 account — the LAYER you'll receive on
+L2 comes out of the L2 bridge vault, not a mint.
+
+`additionalSolGas` is useful on your first bridge: it gives the recipient L2
+SOL to pay for the upcoming `delegate`/`claim` txs. Leave it `0` if you
+already have L2 SOL.
+
+<Note>
+Bridging native SOL instead? Use
+`bridge.createBridgeAssetSourceChainSolTransaction({ bridgeProofNonce, amount, recipient })`.
+</Note>
+
+### Wait for the L2 release to complete
+
+The guardians create a "bridge proof" on L2 when the vault release is done.
+Poll for it using the L1 signature:
+
+```ts
+import { getTargetChainBridgeTxIdFromSourceTxId } from "@solayer-labs/bridge-sdk";
+
+const l2 = new Connection("https://devnet-rpc.solayer.org", "confirmed");
+
+let l2Sig: string | null = null;
+while (!l2Sig) {
+  l2Sig = await getTargetChainBridgeTxIdFromSourceTxId(l1Sig, Chain.Solana, l2);
+  if (!l2Sig) await new Promise((r) => setTimeout(r, 3000));
+}
+console.log("Bridged! L2 completion tx:", l2Sig);
+```
+
+### Confirm what you received on L2
+
+What lands on L2 is LAYER's **original native mint** — on devnet
+`LAYER4xPpTCb3QL8S9u41EAhAX7mhBn8Q6xMTwY2Yzc` — as recorded in the bridge's
+on-chain `TokenInfo` pairing (`solana_mint` = wrapped, `solayer_mint` =
+native). It is *not* a PDA-derived wrapped mint. Check your balance and, once
+the staking program is initialized, verify against the canonical
+`Config.stake_mint`:
+
+```ts
+import { getAssociatedTokenAddressSync, getAccount } from "@solana/spl-token";
+
+// Native LAYER mint on the L2 (devnet). Once the staking program is
+// initialized, read the canonical value from Config.stake_mint instead.
+const L2_LAYER_MINT = new PublicKey(
+  "LAYER4xPpTCb3QL8S9u41EAhAX7mhBn8Q6xMTwY2Yzc",
+);
+
+const l2Ata = getAssociatedTokenAddressSync(L2_LAYER_MINT, wallet.publicKey);
+console.log("Balance:", (await getAccount(l2, l2Ata)).amount.toString());
+// The mint you received MUST equal Config.stake_mint. If not, you
+// bridged the wrong token and cannot stake it.
+```
+
+<Note>
+The bridge SDK's `get_target_mint` helper derives
+`["mint", bridgeHandler, sourceMint]`, which is only meaningful for tokens
+being bridged *away from their home chain* (e.g. a Solana-native token
+heading to the L2). Don't rely on it for the wrapped-LAYER → native-LAYER
+direction documented here — confirm the mint against `Config.stake_mint`
+(or the bridge SDK docs) instead.
+</Note>
+
+## Delegate
+
+Everything from here runs against the **L2 RPC**. We use `@coral-xyz/anchor`
+with the staking program's IDL. Set up the client and PDA helpers once:
+
+```ts
+import * as anchor from "@coral-xyz/anchor";
+import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID, getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import IDL from "./infini_stake.json"; // download: /documentation/staking/infini_stake.json
+
+const STAKE_PROGRAM_ID = new PublicKey(
+  "mi7DC6qnESgL6TWdQn7xJBKqWwv2YiZVeoVuhpXhLvz",
+);
+const l2 = new Connection("https://devnet-rpc.solayer.org", "confirmed");
+
+const wallet = new anchor.Wallet(Keypair.fromSecretKey(/* ... */));
+const provider = new anchor.AnchorProvider(l2, wallet, { commitment: "confirmed" });
+
+// infini-stake is built with Anchor v2: the program ID comes from the IDL's
+// `address` field, so the constructor takes (idl, provider). On older Anchor
+// (0.29) use `new anchor.Program(IDL, STAKE_PROGRAM_ID, provider)` instead.
+const program = new anchor.Program(IDL as anchor.Idl, provider);
+
+const me = wallet.publicKey;
+
+// --- PDAs ---
+const [configPda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("config")], STAKE_PROGRAM_ID);
+
+const validatorPda = (identity: PublicKey) =>
+  PublicKey.findProgramAddressSync(
+    [Buffer.from("validator"), identity.toBuffer()], STAKE_PROGRAM_ID)[0];
+
+const delegationPda = (owner: PublicKey, identity: PublicKey) =>
+  PublicKey.findProgramAddressSync(
+    [Buffer.from("delegation"), owner.toBuffer(), identity.toBuffer()],
+    STAKE_PROGRAM_ID)[0];
+
+// Read config to learn the stake mint + vault (don't hardcode).
+const config = await program.account.config.fetch(configPda);
+const stakeMint = config.stakeMint as PublicKey;
+const stakeVault = config.stakeVault as PublicKey; // = ATA(configPda, stakeMint)
+const myAta = getAssociatedTokenAddressSync(stakeMint, me);
+```
+
+Now delegate. `VALIDATOR_IDENTITY` is the pubkey of the validator you chose;
+the validator must be **active**.
+
+```ts
+const VALIDATOR_IDENTITY = new PublicKey("<validator identity pubkey>"); // TBD
+
+const amount = new anchor.BN(1_000_000_000); // base units; must be > 0
+
+await program.methods
+  .delegate(amount)
+  .accounts({
+    config: configPda,
+    validator: validatorPda(VALIDATOR_IDENTITY),
+    delegation: delegationPda(me, VALIDATOR_IDENTITY),
+    ownerTokenAccount: myAta,
+    stakeVault,
+    stakeMint,
+    owner: me,
+    systemProgram: SystemProgram.programId,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  })
+  .rpc();
+```
+
+What happens: your `amount` is transferred from your ATA into the program
+vault, a `StakeDelegation` account is created (first time only), and any
+already-accrued rewards are settled to your wallet. From this moment your
+position earns the configured APY **less your validator's commission**
+(effective `apy * (1 - commission)`). Calling `delegate` again on the same
+validator tops up the same position.
+
+## Claim, request unstake, complete unstake
+
+### Claim rewards (anytime)
+
+Mints your accrued rewards to your ATA. Safe to call whenever; if nothing
+has accrued it's a no-op.
+
+```ts
+await program.methods
+  .claimRewards()
+  .accounts({
+    config: configPda,
+    validator: validatorPda(VALIDATOR_IDENTITY),
+    delegation: delegationPda(me, VALIDATOR_IDENTITY),
+    ownerTokenAccount: myAta,
+    stakeMint,
+    owner: me,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  })
+  .rpc();
+```
+
+### Request unstake (starts the cooldown)
+
+Moves `amount` of your active stake into a cooldown bucket. It **stops
+earning immediately**; your remaining stake keeps earning. Pending rewards
+are settled in the same call. Only **one** pending unstake per position at a
+time — wait for the current one to complete before requesting another.
+
+```ts
+const unstakeAmount = new anchor.BN(500_000_000); // ≤ delegation.amount
+
+await program.methods
+  .requestUnstake(unstakeAmount)
+  .accounts({
+    config: configPda,
+    validator: validatorPda(VALIDATOR_IDENTITY),
+    delegation: delegationPda(me, VALIDATOR_IDENTITY),
+    ownerTokenAccount: myAta,
+    stakeMint,
+    owner: me,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  })
+  .rpc();
+```
+
+### Complete unstake (after the cooldown)
+
+After `Config.cooldown_seconds` (7 days by default) have passed since the
+request, withdraw the cooled-down tokens from the vault back to your ATA.
+
+```ts
+await program.methods
+  .completeUnstake()
+  .accounts({
+    config: configPda,
+    delegation: delegationPda(me, VALIDATOR_IDENTITY),
+    stakeVault,
+    ownerTokenAccount: myAta,
+    owner: me,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  })
+  .rpc();
+```
+
+Calling before the cooldown elapses fails with `CooldownNotElapsed`; calling
+with nothing pending fails with `NoPendingUnstake`.
+
+## Check your position & the deployment
+
+```ts
+// Global config — APY, cooldown, the canonical stake mint/vault, totals.
+const config = await program.account.config.fetch(configPda);
+console.log("APY (bps):", config.apyBps);
+console.log("Cooldown (s):", config.cooldownSeconds.toString());
+console.log("Stake mint:", config.stakeMint.toBase58());
+// ↑ the native L2 LAYER mint — the token you hold/received must equal it
+console.log("Total active stake:", config.totalActiveStake.toString());
+
+// A validator — is it active, its commission, how much is delegated to it.
+const v = await program.account.validator.fetch(validatorPda(VALIDATOR_IDENTITY));
+console.log("Validator active:", v.active, "total stake:", v.totalStake.toString());
+console.log("Commission (bps):", v.commissionBps); // effective APY = apy * (1 - commissionBps/10000)
+
+// Your position with this validator.
+const d = await program.account.stakeDelegation.fetch(delegationPda(me, VALIDATOR_IDENTITY));
+console.log("Staked:", d.amount.toString());
+console.log("Pending unstake:", d.pendingUnstake.toString());
+console.log("Unstake ready at (unix):", d.unstakeReadyTs.toString());
+```
+
+<Note>
+Amounts are in the token's **base units**. Divide by `10 ** decimals` (read
+`decimals` from the mint via `getMint`) for human-readable values.
+</Note>

--- a/documentation/staking/infini_stake.json
+++ b/documentation/staking/infini_stake.json
@@ -1,0 +1,1298 @@
+{
+  "address": "mi7DC6qnESgL6TWdQn7xJBKqWwv2YiZVeoVuhpXhLvz",
+  "metadata": {
+    "name": "infini_stake",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "infinisvm staking program"
+  },
+  "instructions": [
+    {
+      "name": "accept_admin",
+      "discriminator": [
+        112,
+        42,
+        45,
+        90,
+        116,
+        181,
+        13,
+        170
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "new_admin",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_commission",
+      "discriminator": [
+        12,
+        9,
+        15,
+        170,
+        155,
+        235,
+        124,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "identity"
+              }
+            ]
+          }
+        },
+        {
+          "name": "identity_token_account",
+          "writable": true
+        },
+        {
+          "name": "stake_mint",
+          "writable": true
+        },
+        {
+          "name": "identity",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_rewards",
+      "discriminator": [
+        4,
+        144,
+        132,
+        71,
+        116,
+        23,
+        151,
+        80
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "validator.identity",
+                "account": "Validator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "delegation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "account",
+                "path": "validator.identity",
+                "account": "Validator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "owner_token_account",
+          "writable": true
+        },
+        {
+          "name": "stake_mint",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": [
+            "delegation"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "complete_unstake",
+      "discriminator": [
+        79,
+        98,
+        40,
+        241,
+        100,
+        30,
+        25,
+        234
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "delegation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "account",
+                "path": "delegation.validator_identity",
+                "account": "StakeDelegation"
+              }
+            ]
+          }
+        },
+        {
+          "name": "stake_vault",
+          "writable": true
+        },
+        {
+          "name": "owner_token_account",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": [
+            "delegation"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "deactivate_validator",
+      "discriminator": [
+        188,
+        227,
+        224,
+        187,
+        231,
+        52,
+        3,
+        147
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "identity"
+              }
+            ]
+          }
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "identity",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "delegate",
+      "discriminator": [
+        90,
+        147,
+        75,
+        178,
+        85,
+        88,
+        4,
+        137
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "validator.identity",
+                "account": "Validator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "delegation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "account",
+                "path": "validator.identity",
+                "account": "Validator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "owner_token_account",
+          "writable": true
+        },
+        {
+          "name": "stake_vault",
+          "writable": true
+        },
+        {
+          "name": "stake_mint",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize",
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "stake_mint",
+          "writable": true
+        },
+        {
+          "name": "stake_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "config"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "stake_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "apy_bps",
+          "type": "u16"
+        },
+        {
+          "name": "cooldown_seconds",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "propose_admin",
+      "discriminator": [
+        121,
+        214,
+        199,
+        212,
+        87,
+        39,
+        117,
+        234
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "register_validator",
+      "discriminator": [
+        118,
+        98,
+        251,
+        58,
+        81,
+        30,
+        13,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "identity"
+              }
+            ]
+          }
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "identity",
+          "type": "pubkey"
+        },
+        {
+          "name": "commission_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "request_unstake",
+      "discriminator": [
+        44,
+        154,
+        110,
+        253,
+        160,
+        202,
+        54,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "validator.identity",
+                "account": "Validator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "delegation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "account",
+                "path": "validator.identity",
+                "account": "Validator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "owner_token_account",
+          "writable": true
+        },
+        {
+          "name": "stake_mint",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": [
+            "delegation"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_apy",
+      "discriminator": [
+        161,
+        152,
+        30,
+        236,
+        6,
+        157,
+        152,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_apy_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "set_commission",
+      "discriminator": [
+        193,
+        212,
+        22,
+        184,
+        185,
+        232,
+        22,
+        187
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "validator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  108,
+                  105,
+                  100,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "identity"
+              }
+            ]
+          }
+        },
+        {
+          "name": "identity",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_commission_bps",
+          "type": "u16"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Config",
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
+    },
+    {
+      "name": "StakeDelegation",
+      "discriminator": [
+        165,
+        164,
+        214,
+        92,
+        159,
+        39,
+        35,
+        117
+      ]
+    },
+    {
+      "name": "Validator",
+      "discriminator": [
+        108,
+        40,
+        172,
+        51,
+        190,
+        198,
+        22,
+        15
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidAmount",
+      "msg": "Amount must be greater than zero"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidApy",
+      "msg": "APY exceeds the configured maximum"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidCommission",
+      "msg": "Commission exceeds the configured maximum"
+    },
+    {
+      "code": 6003,
+      "name": "ValidatorInactive",
+      "msg": "Validator is not active"
+    },
+    {
+      "code": 6004,
+      "name": "AlreadyInactive",
+      "msg": "Validator is already inactive"
+    },
+    {
+      "code": 6005,
+      "name": "PendingUnstakeExists",
+      "msg": "A pending unstake already exists for this delegation"
+    },
+    {
+      "code": 6006,
+      "name": "NoPendingUnstake",
+      "msg": "No pending unstake to complete"
+    },
+    {
+      "code": 6007,
+      "name": "CooldownNotElapsed",
+      "msg": "Cooldown has not elapsed"
+    },
+    {
+      "code": 6008,
+      "name": "NotAdmin",
+      "msg": "Signer is not the admin"
+    },
+    {
+      "code": 6009,
+      "name": "Overflow",
+      "msg": "Arithmetic overflow"
+    }
+  ],
+  "types": [
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "stake_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "stake_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "apy_bps",
+            "type": "u16"
+          },
+          {
+            "name": "cooldown_seconds",
+            "type": "i64"
+          },
+          {
+            "name": "last_accrue_ts",
+            "type": "i64"
+          },
+          {
+            "name": "acc_reward_per_share",
+            "type": "u128"
+          },
+          {
+            "name": "total_active_stake",
+            "type": "u64"
+          },
+          {
+            "name": "validator_count",
+            "type": "u32"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakeDelegation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "validator_identity",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "acc_snapshot",
+            "type": "u128"
+          },
+          {
+            "name": "pending_unstake",
+            "type": "u64"
+          },
+          {
+            "name": "unstake_ready_ts",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Validator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "identity",
+            "type": "pubkey"
+          },
+          {
+            "name": "active",
+            "type": "bool"
+          },
+          {
+            "name": "total_stake",
+            "type": "u64"
+          },
+          {
+            "name": "commission_bps",
+            "docs": [
+              "Commission the validator takes out of its delegators' rewards, in bps."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "net_acc",
+            "docs": [
+              "Net (after-commission) reward accumulator. Delegations snapshot THIS, not",
+              "the global `Config.acc_reward_per_share`."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "global_checkpoint",
+            "docs": [
+              "Value of `Config.acc_reward_per_share` at the last `roll_validator`."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "accrued_commission",
+            "docs": [
+              "Commission owed to the validator (token units), claimable via claim_commission."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "commission_remainder",
+            "docs": [
+              "Carried sub-token commission remainder (PRECISION-scaled). Makes realized",
+              "commission independent of how often roll_validator runs (see accrue.rs)."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/documentation/staking/overview.mdx
+++ b/documentation/staking/overview.mdx
@@ -1,0 +1,112 @@
+---
+title: "LAYER Staking Overview"
+description: "How LAYER staking works on the Solayer chain (devnet)"
+---
+
+<Warning>
+**Status: pre-launch.** The staking program (`infini-stake`, ID
+`mi7DC6qnESgL6TWdQn7xJBKqWwv2YiZVeoVuhpXhLvz`) is **not yet
+deployed/initialized on devnet**. The node-run and bridge steps are executable
+today; the `delegate` / `claim` / `unstake` flows light up once the program is
+deployed and initialized. Values that only exist post-launch (live `Config`
+values, validator identities, etc.) are marked **TBD** or as `<placeholder>`;
+token/bridge addresses are **devnet** values.
+</Warning>
+
+This section covers how to **run a staking node** (operator) and how to
+**stake LAYER to a validator** (delegator) on the Solayer chain.
+
+<Info>
+The Solayer chain is SVM-compatible — `@solana/web3.js`, `@solana/spl-token`,
+and `@coral-xyz/anchor` work against the L2 RPC exactly as they do on Solana.
+</Info>
+
+| If you're a… | Read |
+|---|---|
+| Node operator who wants to run a validator | This page, then [Run a Validator](/documentation/staking/run-a-validator) |
+| Token holder who wants to delegate | This page, then [Delegate LAYER](/documentation/staking/delegate) |
+| Integrator / debugging | [Reference](/documentation/staking/reference) |
+
+## How staking works
+
+- You stake **one SPL token** — **LAYER**, the stake token. It is both the
+  asset you stake and the asset you earn rewards in. There is no separate
+  reward token.
+- You **delegate** your tokens to a **validator** (an operator the project has
+  registered). You can split across several validators; each `(you, validator)`
+  pair is an independent position.
+- Rewards accrue **continuously** at the gross APY the admin sets, and are
+  **minted directly to your wallet** when you claim. No epochs, no manual
+  compounding.
+- Each validator charges a **commission** (0–100%, set in basis points) on its
+  delegators' rewards, so your *effective* APY is `apy * (1 - commission)`. The
+  admin sets a validator's initial rate at registration; the validator can
+  change it any time via `set_commission` (only future rewards are affected)
+  and collects it on-chain via `claim_commission`.
+- Unstaking has a **cooldown** (7 days by default). You request, wait, then
+  withdraw. The portion in cooldown stops earning immediately.
+
+The staking program (`infini-stake`) runs **on the L2**, and it accepts the
+**L2-native LAYER mint**. LAYER's home chain is the L2 — it is a
+Solayer-native token, not a Solana token bridged in — so if you already hold
+LAYER on the L2 you can delegate straight away, no bridging needed. Only
+holders of the **wrapped** form on Solana (L1) have to
+[bridge it back](/documentation/staking/delegate#bridge-wrapped-layer-l1-to-l2)
+first.
+
+A "validator" in this program is just a registered pubkey on-chain — an
+**identity**. The node software (`rpc-v2`) does not sign anything for the
+staking program; the admin allowlists who counts as a validator out-of-band.
+Running a node is the *service* that earns you a spot on that allowlist.
+
+### Lifecycle at a glance
+
+```
+  (L1) wrapped LAYER ──bridge──▶ (L2) hold LAYER ──delegate──▶ earning rewards
+   (skip if you already hold                                          │
+    LAYER on the L2)            claim_rewards ◀── anytime ────────────┤
+                                                                      │
+   withdrawn ◀── complete_unstake ◀── wait 7d ◀── request_unstake ────┘
+```
+
+## Network endpoints & addresses
+
+| Thing | Value |
+|---|---|
+| L1 RPC (Solana devnet) | `https://api.devnet.solana.com` |
+| L2 RPC (Solayer devnet, public) | `https://devnet-rpc.solayer.org` |
+| L2 explorer | `https://explorer.solayer.org` |
+| **Sequencer gRPC** (rpc-v2 upstream) | `http://devnet-seed-1.solayer.org:5005` |
+| **Sequencer HTTP registry** | `http://devnet-seed-1.solayer.org:6005` |
+| **Sequencer JSON-RPC** (upstream fallback) | `http://devnet-seed-1.solayer.org:8899` |
+| Sequencer pubkey (for signature verification) | **TBD** — request from the team |
+| Bridge program (both chains) | `6kpxYKjqe8z66hnDHbbjhEUxha46cnz2UqrneGECmFBg` |
+| Bridge handler PDA (same address on both chains) | `55uVZhH3jk95dLdnsJwMAG72pecMwa8MTjVH4ni7osBy` |
+| Bridge SDK (npm) | `@solayer-labs/bridge-sdk` |
+| Staking program (`infini-stake`, L2) | `mi7DC6qnESgL6TWdQn7xJBKqWwv2YiZVeoVuhpXhLvz` |
+| **Stake token: LAYER** — native **L2** mint (devnet) | `LAYER4xPpTCb3QL8S9u41EAhAX7mhBn8Q6xMTwY2Yzc` (9 decimals) |
+| Wrapped LAYER — **L1** mint (devnet, bridge-derived) | `CJYj22nRQ7uQAV6Rmvn4sy2NduBiFwLNqdqkmH6hWDEF` |
+
+The stake token is **LAYER**, and it is **Solayer-L2-native**: the L2 mint
+above is the token's home, and the L1 mint is only a **wrapped**
+representation created by the bridge (its mint authority is the bridge
+handler PDA). The token/bridge addresses are **devnet** values — mainnet may
+differ, and the canonical source of truth once the program is initialized is
+`Config.stake_mint` (see
+[Check your position](/documentation/staking/delegate#check-your-position--the-deployment)).
+
+### Post-launch values (TBD)
+
+These only exist after the staking program is deployed and `initialize`d:
+
+- **`Config.stake_mint`** — expected to be the **native L2 LAYER mint** above.
+  Whatever you hold or receive on L2 must equal this value, or `delegate`
+  rejects it. (The L1 mint is only the wrapped form — the program does not
+  accept it.)
+- **Validator identity pubkey(s)** — registered validators you can delegate to.
+
+The program **IDL** is already available:
+[`infini_stake.json`](/documentation/staking/infini_stake.json) (served from
+these docs, generated from the program source). You'll need it for the
+TypeScript snippets in the [Delegate LAYER](/documentation/staking/delegate)
+page.

--- a/documentation/staking/reference.mdx
+++ b/documentation/staking/reference.mdx
@@ -1,0 +1,94 @@
+---
+title: "Staking Reference"
+description: "PDA seeds, instruction accounts, error codes, and FAQ"
+---
+
+## PDA seeds & instruction account checklist
+
+**PDA seeds (all under the staking program):**
+
+| Account | Seeds |
+|---|---|
+| `Config` (singleton) | `["config"]` |
+| `Validator` | `["validator", validator_identity]` |
+| `StakeDelegation` (your position) | `["delegation", owner, validator_identity]` |
+| `stake_vault` | ATA of the `Config` PDA for `stake_mint` (also stored in `Config.stake_vault`) |
+
+**Instruction account checklist:**
+
+| Instruction | Accounts |
+|---|---|
+| `delegate(amount)` | config, validator*, delegation, ownerTokenAccount, stakeVault, stakeMint, owner(signer), systemProgram, tokenProgram |
+| `claimRewards()` | config, validator, delegation, ownerTokenAccount, stakeMint, owner(signer), tokenProgram |
+| `requestUnstake(amount)` | config, validator, delegation, ownerTokenAccount, stakeMint, owner(signer), tokenProgram |
+| `completeUnstake()` | config, delegation, stakeVault, ownerTokenAccount, owner(signer), tokenProgram |
+
+\* validator must be **active** for `delegate`.
+
+**Validator-operator instructions** — signed by the validator **identity**
+wallet, not the admin (the `["validator", identity]` seeds bind the signer):
+
+| Instruction | Accounts |
+|---|---|
+| `setCommission(newCommissionBps)` | config, validator, identity(signer) |
+| `claimCommission()` | config, validator, identityTokenAccount, stakeMint, identity(signer), tokenProgram |
+
+Admin-only instructions (not used directly by operators or delegators):
+`initialize`, `set_apy`, `propose_admin`, `accept_admin`,
+`register_validator`, `deactivate_validator`.
+
+## Error codes
+
+| Error | Meaning / fix |
+|---|---|
+| `InvalidAmount` | Amount was `0`, or unstake amount exceeded your stake. |
+| `ValidatorInactive` | The validator was deactivated — you can't add new stake to it. (You can still claim and unstake.) |
+| `PendingUnstakeExists` | You already have a cooldown in flight on this position. Complete it first. |
+| `NoPendingUnstake` | `completeUnstake` with nothing pending. |
+| `CooldownNotElapsed` | `completeUnstake` called before the 7-day cooldown finished. |
+| `NotAdmin` | Admin-only path called by non-admin (shouldn't hit this as an operator/delegator). |
+| `InvalidCommission` | `register_validator` / `set_commission` got a rate above 100% (`> 10000` bps). |
+| `InvalidApy` / `AlreadyInactive` / `Overflow` | Admin-side or near-impossible cases. |
+
+## FAQ
+
+- **Do I have to run a node to delegate?** No. Delegators only need LAYER on
+  the L2 and a wallet. Running a node is for operators who want to be
+  registered as a validator.
+- **Do I earn from other people's delegations?** Yes — as a validator you take
+  a **commission** (0–100%, in bps) out of your delegators' rewards. The admin
+  sets your initial rate at registration; you can change it any time with
+  `set_commission` (future rewards only) and mint what's accrued to your own
+  token account with `claim_commission`.
+- **Do I earn on stake that's in cooldown?** No. From the moment you
+  `requestUnstake`, that portion stops accruing. Your remaining `amount`
+  keeps earning (if the validator is still active).
+- **What if my validator gets deactivated?** Your rewards freeze at the
+  deactivation point, but you can still `claimRewards` what accrued and
+  `requestUnstake` / `completeUnstake` normally. To keep earning, unstake and
+  delegate to an active validator. Deactivation is permanent — the operator
+  would have to be re-registered under a fresh identity pubkey.
+- **Can I delegate to several validators?** Yes — one `StakeDelegation` per
+  validator, all independent. Repeat the
+  [delegate flow](/documentation/staking/delegate#delegate) with each
+  validator's identity.
+- **Where do rewards land?** Directly in your LAYER ATA, on claim and
+  on every `delegate` / `requestUnstake` (which settle pending first).
+- **Can I cancel a pending unstake?** No (v1). Wait out the cooldown,
+  withdraw, then re-delegate if you want back in.
+- **My rpc-v2 node serves a different JSON-RPC port than the public devnet
+  RPC. Do I have to use the public one for staking txs?** No. Once your node
+  is caught up, point your client at `http://<your-node>:18899` instead of
+  `https://devnet-rpc.solayer.org` — it's the same network.
+
+## See also
+
+- Bridge SDK: [`@solayer-labs/bridge-sdk`](https://www.npmjs.com/package/@solayer-labs/bridge-sdk)
+  on npm, and [Solayer Bridge](/documentation/solayer-bridge/introduction) in
+  these docs.
+- Node software: the
+  [solayer-rpc repository](https://github.com/solayer-labs/solayer-rpc)
+  (`rpc-v2`, `registry-probe`).
+- Staking program (`infini-stake`): program ID
+  `mi7DC6qnESgL6TWdQn7xJBKqWwv2YiZVeoVuhpXhLvz`; IDL:
+  [`infini_stake.json`](/documentation/staking/infini_stake.json).

--- a/documentation/staking/run-a-validator.mdx
+++ b/documentation/staking/run-a-validator.mdx
@@ -1,0 +1,314 @@
+---
+title: "Run a Validator"
+description: "Run a devnet staking node and register as a validator"
+---
+
+<Note>
+This page targets **devnet**. For a mainnet-alpha RPC node (different
+endpoints and build flags), see
+[Mainnet Alpha Node](/documentation/run-a-node/mainnet-alpha). Start with the
+[LAYER Staking Overview](/documentation/staking/overview) if you haven't read
+it yet.
+</Note>
+
+## What "running a staking node" means here
+
+There are **two separate things** that together make you a "validator":
+
+1. **Run an `rpc-v2` node** — a follower RPC that syncs from the project's
+   central sequencer over gRPC and serves Solana-compatible JSON-RPC. This is
+   what you operate as infrastructure. The node binary itself has **no
+   built-in staking logic**.
+2. **Hold a "validator identity" pubkey** that the project's admin has
+   registered in the `infini-stake` program. That on-chain registration is
+   what makes the identity eligible to be delegated to.
+
+The build/run steps below set up #1. The
+[registration step](#get-your-identity-registered-as-a-validator) sets up #2.
+[Self-delegating](#self-delegate-to-start-earning) makes the identity
+actually earn.
+
+<Info>
+**Economics callout.** Your on-chain income has **two** parts: rewards on
+your **own self-delegation**, plus the **commission** (0–100%, in bps) you
+take out of *other* delegators' rewards. The admin sets your initial
+commission at registration; you change it any time via `set_commission`
+(future rewards only) and withdraw what's accrued via `claim_commission`.
+Any extra off-chain compensation for running infrastructure is separate.
+</Info>
+
+## Build the node
+
+The node software lives in the
+[solayer-rpc repository](https://github.com/solayer-labs/solayer-rpc); the
+required toolchain is pinned in its `rust-toolchain.toml`. For devnet, build
+without the `mainnet` feature:
+
+```bash
+git clone https://github.com/solayer-labs/solayer-rpc
+cd solayer-rpc
+rustup show                          # pulls the pinned Rust toolchain
+cargo build --release -p rpc-v2
+```
+
+The binary lands at `target/release/rpc-v2`. The sequencer binary
+(`target/release/sequencer`) is for the project; you don't run it.
+
+**System requirements (rough guidance):**
+- Linux x86_64 (macOS works for development).
+- 8 GB RAM or more (16 GB comfortable).
+- 200 GB+ disk for slots/chaindata growth on devnet; consider a dedicated
+  SSD/NVMe.
+- Stable public IPv4 if you want other RPC nodes to peer with you (set
+  `--grpc-advertise-addr`).
+
+## Generate your validator identity keypair
+
+The "validator identity" is a Solana keypair you control. It's used by the
+staking program (never by the node binary) for three things:
+
+- The admin registers its **public key** via
+  `register_validator(identity, commission_bps)`.
+- You can **self-delegate** to it from any wallet (using its secret key is
+  convenient but not required — anyone holding the stake token can delegate
+  to this identity).
+- It is the **only** signer allowed to call `set_commission` (change your
+  commission rate) and `claim_commission` (mint accrued commission to your own
+  token account) — both bound to the keypair by the `["validator", identity]`
+  PDA seeds, and commission pays out to an ATA this identity owns. So the
+  **secret key is required** to manage and collect commission, not just
+  convenient.
+
+Generate with the Solana CLI:
+
+```bash
+solana-keygen new \
+  --no-bip39-passphrase \
+  -o ~/.config/solana/infinisvm-validator.json
+solana-keygen pubkey ~/.config/solana/infinisvm-validator.json
+# → this pubkey is what you'll send to the admin for registration
+```
+
+<Warning>
+Keep the secret key safe. It is your validator identity for as long as
+you're in the allowlist. Deactivation is **permanent** — if you lose the
+key, the admin can register you under a new pubkey, but the old one cannot
+be reactivated.
+</Warning>
+
+<Note>
+The node software (`rpc-v2`) does **not** read this keypair. There is no
+`--identity-keypair` flag on `rpc-v2`. Keep it separate from any node-host
+credentials.
+</Note>
+
+## Run rpc-v2 against the devnet sequencer
+
+Minimal invocation, connecting to the project's devnet sequencer
+(`devnet-seed-1.solayer.org`). Replace `<SEQUENCER_PUBKEY>` and `<YOUR_PUBLIC_IP>` with
+real values; ask the team for the sequencer pubkey.
+
+```bash
+mkdir -p /var/lib/infinisvm/{slots,chaindata,logs}
+
+RUST_LOG=info ./target/release/rpc-v2 \
+  --sequencer-grpc-server-addr http://devnet-seed-1.solayer.org:5005 \
+  --sequencer-http-server-addr http://devnet-seed-1.solayer.org:6005 \
+  --sequencer-rpc-server-addr  http://devnet-seed-1.solayer.org:8899 \
+  --rpc-registry-addrs         http://devnet-seed-1.solayer.org:6005 \
+  --sequencer-pubkey           <SEQUENCER_PUBKEY> \
+  --grpc-listen-addr           0.0.0.0:15005 \
+  --grpc-advertise-addr        <YOUR_PUBLIC_IP>:15005 \
+  --listen-addr                0.0.0.0:18899 \
+  --metric-addr                127.0.0.1:3002 \
+  --local-slots-path           /var/lib/infinisvm/slots \
+  --local-db-path              /var/lib/infinisvm/chaindata \
+  --start-slot                 latest \
+  2>&1 | tee /var/lib/infinisvm/logs/rpc-v2.log
+```
+
+**What each flag does (highlights):**
+
+- `--sequencer-grpc-server-addr` — primary gRPC upstream for block sync.
+- `--sequencer-http-server-addr` / `--sequencer-rpc-server-addr` — snapshot
+  bootstrap and JSON-RPC fallback to the sequencer.
+- `--rpc-registry-addrs` — registry to register yourself with, comma-separated
+  if you want to point at multiple.
+- `--sequencer-pubkey` — required; rpc-v2 verifies the sequencer's
+  finalization signature with this. A mismatch makes the node refuse to
+  finalize blocks.
+- `--grpc-listen-addr` — where your node serves gRPC sync to *downstream*
+  subscribers (peers, indexers).
+- `--grpc-advertise-addr` — the public address you announce to the registry
+  so other nodes can dial you. Set to your public IP/DNS if exposed.
+- `--listen-addr` — your Solana-compatible JSON-RPC for clients (web3.js,
+  Anchor, etc.).
+- `--metric-addr` — Prometheus metrics endpoint.
+- `--start-slot latest` — start tailing from the current tip. Avoid
+  `checkpoint` (would need S3 access to `s3://solayer-devnet`).
+
+### Optional: Cassandra indexer + S3
+
+These are **not required** for a follower that just syncs + serves RPC. They
+add:
+
+- `--cassandra-hosts host1:9042,host2:9042 --cassandra-replication-factor N` —
+  enables indexed historical queries (transaction-by-signature, etc.). Stand
+  up your own ScyllaDB/Cassandra cluster if you need this.
+- `--s3-path`, `--s3-access-key-id` (env `S3_ACCESS_KEY_ID`), `--s3-secret-key`
+  (env `S3_SECRET_KEY`), `--s3-region` — for snapshot/slot backfill from S3.
+  Project-internal on devnet today; skip unless you've been given creds.
+
+### systemd unit (example)
+
+```ini
+# /etc/systemd/system/rpc-v2.service
+[Unit]
+Description=infinisvm rpc-v2
+After=network-online.target
+
+[Service]
+User=infinisvm
+WorkingDirectory=/opt/infinisvm
+Environment=RUST_LOG=info
+ExecStart=/opt/infinisvm/target/release/rpc-v2 \
+  --sequencer-grpc-server-addr http://devnet-seed-1.solayer.org:5005 \
+  --sequencer-http-server-addr http://devnet-seed-1.solayer.org:6005 \
+  --sequencer-rpc-server-addr  http://devnet-seed-1.solayer.org:8899 \
+  --rpc-registry-addrs         http://devnet-seed-1.solayer.org:6005 \
+  --sequencer-pubkey           <SEQUENCER_PUBKEY> \
+  --grpc-listen-addr           0.0.0.0:15005 \
+  --grpc-advertise-addr        <YOUR_PUBLIC_IP>:15005 \
+  --listen-addr                0.0.0.0:18899 \
+  --metric-addr                127.0.0.1:3002 \
+  --local-slots-path           /var/lib/infinisvm/slots \
+  --local-db-path              /var/lib/infinisvm/chaindata \
+  --start-slot                 latest
+Restart=always
+RestartSec=5
+LimitNOFILE=200000
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now rpc-v2
+sudo journalctl -fu rpc-v2
+```
+
+## Verify the node is syncing
+
+**JSON-RPC `getSlot` should advance**:
+
+```bash
+watch -n 1 'curl -s http://127.0.0.1:18899 \
+  -H content-type:application/json \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getSlot\",\"params\":[]}"'
+```
+
+Compare against the public sequencer:
+
+```bash
+curl -s http://devnet-seed-1.solayer.org:8899 \
+  -H content-type:application/json \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[]}'
+```
+
+Your lag should be small (single-digit slots in steady state) once caught up.
+
+**Prometheus metrics**:
+
+```bash
+curl -s http://127.0.0.1:3002/metrics | head -50
+```
+
+**Peer/registry status** (uses the `registry-probe` helper binary from the
+same repo):
+
+```bash
+./target/release/registry-probe registry --addr http://devnet-seed-1.solayer.org:6005
+./target/release/registry-probe node --grpc http://127.0.0.1:15005
+```
+
+**Common failure modes:**
+
+| Symptom | Likely cause |
+|---|---|
+| Node exits with "signature verification failed" | Wrong `--sequencer-pubkey`. Re-fetch from the team. |
+| `failed to connect to gRPC` | Sequencer host/port unreachable. Check egress to `devnet-seed-1.solayer.org:5005`. |
+| Slot frozen / never advances | Upstream momentarily down, or `--start-slot` is in the wrong mode. Try `latest`. |
+| Disk fills up | Slots/chaindata grow. Mount a larger volume; rotate logs. |
+
+## Get your identity registered as a validator
+
+Validator allowlisting is admin-controlled and off-chain. Once your node is
+syncing and your identity keypair is ready:
+
+1. **Contact the project team.** Send them:
+   - Your validator identity **pubkey**.
+   - Your node's `--grpc-advertise-addr` so they can verify it's reachable.
+   - Any operator metadata they ask for (contact, name to display, etc.).
+
+2. **Admin runs `register_validator(identity, commission_bps)`.** This creates
+   a `Validator` PDA at seeds `["validator", identity]` with `active = true`
+   and your commission rate set to `commission_bps` (basis points, capped at
+   `MAX_COMMISSION_BPS = 10000` = 100%; otherwise rejected with
+   `InvalidCommission`). You can change the rate later via `set_commission`.
+
+3. **Verify on-chain.** Once registered:
+
+   ```ts
+   import * as anchor from "@coral-xyz/anchor";
+   import { Connection, PublicKey } from "@solana/web3.js";
+   import IDL from "./infini_stake.json"; // download: /documentation/staking/infini_stake.json
+
+   const STAKE_PROGRAM_ID = new PublicKey(
+     "mi7DC6qnESgL6TWdQn7xJBKqWwv2YiZVeoVuhpXhLvz",
+   );
+   const l2 = new Connection("https://devnet-rpc.solayer.org", "confirmed");
+   const provider = new anchor.AnchorProvider(
+     l2, new anchor.Wallet(anchor.web3.Keypair.generate()), {});
+   const program = new anchor.Program(IDL as anchor.Idl, provider);
+
+   const myIdentity = new PublicKey("<your validator identity pubkey>");
+   const [validatorPda] = PublicKey.findProgramAddressSync(
+     [Buffer.from("validator"), myIdentity.toBuffer()],
+     STAKE_PROGRAM_ID,
+   );
+   const v = await program.account.validator.fetch(validatorPda);
+   console.log("active:", v.active, "total_stake:", v.totalStake.toString());
+   ```
+
+<Note>
+The node binary doesn't know about — and isn't notified by — this
+registration. It's purely an on-chain effect.
+</Note>
+
+## Self-delegate to start earning
+
+Your on-chain staking income has two parts: rewards on your own
+self-delegation, plus the commission you take from any other delegators (set
+by the admin at registration, adjustable via `set_commission`, collected via
+`claim_commission`). To earn on your own stake, follow
+[Delegate LAYER](/documentation/staking/delegate) from your validator's
+perspective:
+
+1. Acquire **LAYER on the L2** (devnet mint in the
+   [overview](/documentation/staking/overview#network-endpoints--addresses)).
+   LAYER is L2-native, so you may already hold it there; if what you hold is
+   the **wrapped** form on Solana (L1),
+   [bridge it back to L2](/documentation/staking/delegate#bridge-wrapped-layer-l1-to-l2)
+   first.
+2. **Delegate to your own identity pubkey** — the `validator_identity` you
+   pass to the delegation PDA is your validator's pubkey; the `owner`
+   (signer) can be the same keypair or a different wallet that holds the
+   stake token.
+
+After delegation the rewards accumulate continuously and you can `claim` to
+your wallet whenever you want.
+
+Your **commission** on *other* delegators' stake accrues separately — mint it
+to your own token account any time with `claim_commission` (see the
+[reference](/documentation/staking/reference)).

--- a/mint.json
+++ b/mint.json
@@ -121,6 +121,15 @@
             ]
         },
         {
+            "group": "LAYER Staking",
+            "pages": [
+                "documentation/staking/overview",
+                "documentation/staking/run-a-validator",
+                "documentation/staking/delegate",
+                "documentation/staking/reference"
+            ]
+        },
+        {
             "group": "Solayer Bridge",
             "pages": [
                 "documentation/solayer-bridge/introduction",


### PR DESCRIPTION
Four new pages under a LAYER Staking nav group: overview, run a validator, delegate, and reference — adapted from the internal staking guide for the infini-stake program. Ships the program IDL (infini_stake.json) as a static asset and references the public solayer-rpc repo and devnet-seed-1.solayer.org endpoints.